### PR TITLE
fix: use grpc service for grpc ingress

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 7.0.2
+version: 7.0.3

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -29,7 +29,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.query.ingress.grpc.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "grpc" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.query.ingress.grpc.extraHosts }}
     - host: {{ .name }}


### PR DESCRIPTION
**Description of the change**

Thanos query ingress does not use the right service port, it should be `grpc` and not `http`. This was broken by v7

**Benefits**

GRPC Ingress working for query

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
